### PR TITLE
Bump jsdoc to 3.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -886,9 +886,9 @@
       "dev": true
     },
     "entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-      "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
     },
     "es6-error": {
       "version": "4.1.1",
@@ -1336,9 +1336,9 @@
       "dev": true
     },
     "jsdoc": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.4.tgz",
-      "integrity": "sha512-3G9d37VHv7MFdheviDCjUfQoIjdv4TC5zTTf5G9VODLtOnVS6La1eoYBDlbWfsRT3/Xo+j2MIqki2EV12BZfwA==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
+      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
       "requires": {
         "@babel/parser": "^7.9.4",
         "bluebird": "^3.7.2",
@@ -2216,9 +2216,9 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "collect-all": "^1.0.3",
     "file-set": "^4.0.1",
     "fs-then-native": "^2.0.0",
-    "jsdoc": "^3.6.4",
+    "jsdoc": "^3.6.6",
     "object-to-spawn-args": "^2.0.0",
     "temp-path": "^1.0.0",
     "walk-back": "^4.0.0"


### PR DESCRIPTION
Bump `jsdoc` dependency from 3.6.4 to 3.6.6.

Version 3.6.4 depends on an old version of [`marked`](https://www.npmjs.com/package/marked) that includes this vulnerability: [WS-2020-0163](https://www.whitesourcesoftware.com/vulnerability-database/WS-2020-0163).

Confirmed before push that all tests pass after bump:
```
$ npm run test

> jsdoc-api@6.0.0 test /home/josh/git/joshbwlng/jsdoc-api
> test-runner --max-file-concurrency 1 test/*.js


Start: 16 tests loaded

✓ caching .explainSync({ files, cache: true }) 190.8ms
✓ caching .explain({ files, cache: true  }) 193.3ms
✓ caching .explain({ source, cache: true  }) - Ensure correct output (#147) 419.5ms
✓ explain .explain: file doesn't exist 7.6ms
✓ explain .explain({ files }): generate a warning [[object Object],[object Object]] 174.3ms
✓ explain .explain({ files }) 195.5ms
✓ explain .explain: invalid doclet syntax 225.5ms
✓ explain .explain({ source }) 236.0ms
✓ explain-sync .explainSync({ files }) 181.7ms
✓ explain-sync .explainSync({ source }) 183.6ms
✓ explain-sync .explainSync({ source }), defaults 173.9ms
✓ explain-sync .explainSync: no valid files 129.0ms
✓ explain-sync .explainSync: missing files 0.5ms
✓ explain-sync .explainSync: invalid doclet syntax 174.1ms
✓ render-sync .renderSync({ files }) 212.3ms
✓ render-sync .renderSync({ source, destination }) 214.7ms

Completed in 0ms. Pass: 16, fail: 0, skip: 0.
```