### PR TITLE
Update jsdoc to 3.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "collect-all": "^1.0.4",
         "file-set": "^4.0.2",
         "fs-then-native": "^2.0.0",
-        "jsdoc": "^3.6.6",
+        "jsdoc": "^3.6.7",
         "object-to-spawn-args": "^2.0.1",
         "temp-path": "^1.0.0",
         "walk-back": "^5.0.0"
@@ -685,14 +685,14 @@
       "dev": true
     },
     "node_modules/catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dependencies": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.15"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 10"
       }
     },
     "node_modules/chalk": {
@@ -1099,18 +1099,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/dmd/node_modules/marked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
-      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">= 8.16.2"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -1744,24 +1732,24 @@
       "dev": true
     },
     "node_modules/jsdoc": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
-      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+      "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
       "dependencies": {
         "@babel/parser": "^7.9.4",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
+        "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.1",
         "klaw": "^3.0.0",
         "markdown-it": "^10.0.0",
         "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
+        "marked": "^2.0.3",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
         "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
+        "underscore": "~1.13.1"
       },
       "bin": {
         "jsdoc": "jsdoc.js"
@@ -2029,14 +2017,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
       "bin": {
         "marked": "bin/marked"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">= 10"
       }
     },
     "node_modules/mdurl": {
@@ -3099,9 +3087,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3883,11 +3871,11 @@
       "dev": true
     },
     "catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.15"
       }
     },
     "chalk": {
@@ -4214,14 +4202,6 @@
         "reduce-without": "^1.0.1",
         "test-value": "^3.0.0",
         "walk-back": "^5.0.0"
-      },
-      "dependencies": {
-        "marked": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
-          "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
-          "dev": true
-        }
       }
     },
     "ecc-jsbn": {
@@ -4704,24 +4684,24 @@
       "dev": true
     },
     "jsdoc": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
-      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+      "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
       "requires": {
         "@babel/parser": "^7.9.4",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
+        "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.1",
         "klaw": "^3.0.0",
         "markdown-it": "^10.0.0",
         "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
+        "marked": "^2.0.3",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
         "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
+        "underscore": "~1.13.1"
       }
     },
     "jsdoc-api": {
@@ -4932,9 +4912,9 @@
       "requires": {}
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA=="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -5764,9 +5744,9 @@
       "optional": true
     },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "collect-all": "^1.0.4",
     "file-set": "^4.0.2",
     "fs-then-native": "^2.0.0",
-    "jsdoc": "^3.6.6",
+    "jsdoc": "^3.6.7",
     "object-to-spawn-args": "^2.0.1",
     "temp-path": "^1.0.0",
     "walk-back": "^5.0.0"


### PR DESCRIPTION
jsdoc 3.6.7 updates underscore to 1.13.1, which solves CVE-2021-23358
(https://github.com/advisories/GHSA-cf4h-3jhx-xvhq).