### PR TITLE
Added support for attached vscode debugger

### DIFF
--- a/lib/jsdoc-command.js
+++ b/lib/jsdoc-command.js
@@ -104,7 +104,24 @@ class JsdocCommand {
     try {
       parsedOutput = JSON.parse(output.stdout)
     } catch (err) {
-      parseFailed = true
+      if (output.stdout.toLowerCase().includes('debugger') || (output.stderr && output.stderr.toLowerCase().includes('debugger'))) {
+        try {
+          let lines = output.stdout.split(/\r?\n/);
+          let firstIndex = lines.findIndex(line => line === '[');
+          if (firstIndex > -1) {
+            lines = lines.slice(firstIndex);
+            let stdout = lines.join('\r\n');
+            parsedOutput = JSON.parse(stdout)
+          } else {
+            parseFailed = true
+          }
+
+        } catch (err2) {
+          parseFailed = true
+        }
+      } else {
+        parseFailed = true
+      }
     }
 
     if (code > 0 || parseFailed) {


### PR DESCRIPTION
Use case:
Debugging tooling that uses jsdoc-api causes 

> JSDOC_ERROR: Debugger attached

to be thrown, even when the jsdoc command executed succesfully. This prevents debugging past any jsdoc-api usage as it will always throw an exception when the debugger is attached.

This pull request checks the output of the jsdoc command and if it determines that it failed to parse the output due to the debugger being attached, it finds the start of the actual jsdoc output and attempts to reparse the output from that line.

Commit comment:
[Added support for attached vscode debugger](https://github.com/jsdoc2md/jsdoc-api/commit/8236604d1203a480cacd8663650e4e80f84babeb)