### PR TITLE
Changing 'glob' (v8.0.0) to 'fast-glob' (8.1.0) introduces a breaking change

### DIFF
--- a/lib/jsdoc-command.js
+++ b/lib/jsdoc-command.js
@@ -68,7 +68,8 @@ class JsdocCommand {
    */
   preExecute () {
     const fastGlob = require('fast-glob')
-    const files = fastGlob.globSync(this.options.files, { onlyFiles: true })
+    const normalizePath = require('normalize-path')
+    const files = fastGlob.globSync(this.options.files.map(file => normalizePath(file)),{ onlyFiles: true })
     this.inputFileSet = { files }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "collect-all": "^1.0.4",
         "fs-then-native": "^2.0.0",
         "jsdoc": "^4.0.3",
+        "normalize-path": "^3.0.0",
         "object-to-spawn-args": "^2.0.1",
         "temp-path": "^1.0.0",
         "walk-back": "^5.1.0"
@@ -1605,6 +1606,14 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "collect-all": "^1.0.4",
     "fs-then-native": "^2.0.0",
     "jsdoc": "^4.0.3",
+    "normalize-path": "^3.0.0",
     "object-to-spawn-args": "^2.0.1",
     "temp-path": "^1.0.0",
     "walk-back": "^5.1.0"


### PR DESCRIPTION
On win32, because fast-glob doesn't support paths with backslashes. This is the default path format on Windows when using node:path to resolve and join paths. To cope with this and maintain compatibility, pipe user-supplied paths through `normalize-path` before passing to `fast-glob` so we can ensure paths are always unix style.

Version `8.0.0`:

* macOS & Windows: `jsdoc.explainSync({ files: '/src/myproject/myfile.js' })` -> ok
* win32: `jsdoc.explainSync({ files: 'C:\\src\\myproject\\myfile.js' })` -> ok

Version `8.1.0`

* macOS & Windows: `jsdoc.explainSync({ files: '/src/myproject/myfile.js' })` -> ok
* win32: `jsdoc.explainSync({ files: 'C:\\src\\myproject\\myfile.js' })` -> **No input files to process**
* win32: `jsdoc.explainSync({ files: '/src/myproject/myfile.js' })` -> ok

